### PR TITLE
Add option to ArbitraryFileCache to deactivate default excludes (fixes #39)

### DIFF
--- a/src/main/java/jenkins/plugins/itemstorage/ObjectPath.java
+++ b/src/main/java/jenkins/plugins/itemstorage/ObjectPath.java
@@ -72,7 +72,7 @@ public abstract class ObjectPath {
      * @throws InterruptedException
      */
     public int copyRecursiveTo(String fileMask, FilePath target) throws IOException, InterruptedException {
-        return copyRecursiveTo(fileMask, null, target);
+        return copyRecursiveTo(fileMask, null, true, target);
     }
 
     /**
@@ -85,7 +85,7 @@ public abstract class ObjectPath {
      * @throws IOException
      * @throws InterruptedException
      */
-    public abstract int copyRecursiveTo(String fileMask, String excludes, FilePath target) throws IOException, InterruptedException;
+    public abstract int copyRecursiveTo(String fileMask, String excludes, boolean useDefaultExcludes, FilePath target) throws IOException, InterruptedException;
 
     /**
      * Copy to this object path from the pass file source
@@ -109,7 +109,7 @@ public abstract class ObjectPath {
      * @throws InterruptedException
      */
     public int copyRecursiveFrom(String fileMask, FilePath source) throws IOException, InterruptedException {
-        return copyRecursiveFrom(fileMask, null, source);
+        return copyRecursiveFrom(fileMask, null, true, source);
     }
 
     /**
@@ -122,7 +122,7 @@ public abstract class ObjectPath {
      * @throws IOException
      * @throws InterruptedException
      */
-    public abstract int copyRecursiveFrom(String fileMask, String excludes, FilePath source) throws IOException, InterruptedException;
+    public abstract int copyRecursiveFrom(String fileMask, String excludes, boolean useDefaultExcludes, FilePath source) throws IOException, InterruptedException;
 
     /**
      * Check if this path actually exists
@@ -147,5 +147,5 @@ public abstract class ObjectPath {
      * @param job
      * @return
      */
-    public abstract HttpResponse browse(StaplerRequest request, StaplerResponse response, Job<?,?> job, String name) throws IOException;
+    public abstract HttpResponse browse(StaplerRequest request, StaplerResponse response, Job<?, ?> job, String name) throws IOException;
 }

--- a/src/main/java/jenkins/plugins/itemstorage/local/LocalObjectPath.java
+++ b/src/main/java/jenkins/plugins/itemstorage/local/LocalObjectPath.java
@@ -60,15 +60,15 @@ public class LocalObjectPath extends ObjectPath {
     }
 
     @Override
-    public int copyRecursiveTo(String fileMask, String excludes, FilePath target) throws IOException, InterruptedException {
+    public int copyRecursiveTo(String fileMask, String excludes, boolean useDefaultExcludes, FilePath target) throws IOException, InterruptedException {
         LOGGER.info("Copying from " + file + " to " + target);
-        return file.copyRecursiveTo(new IsModifiedGlob(fileMask, excludes, target), target, fileMask);
+        return file.copyRecursiveTo(new IsModifiedGlob(fileMask, excludes, useDefaultExcludes, target), target, fileMask);
     }
 
     @Override
-    public int copyRecursiveFrom(String fileMask, String excludes, FilePath source) throws IOException, InterruptedException {
+    public int copyRecursiveFrom(String fileMask, String excludes, boolean useDefaultExcludes, FilePath source) throws IOException, InterruptedException {
         LOGGER.info("Copying from " + source + " to " + file);
-        return source.copyRecursiveTo(new IsModifiedGlob(fileMask, excludes, file), file, fileMask);
+        return source.copyRecursiveTo(new IsModifiedGlob(fileMask, excludes, useDefaultExcludes, file), file, fileMask);
     }
 
     @Override
@@ -82,7 +82,7 @@ public class LocalObjectPath extends ObjectPath {
     }
 
     @Override
-    public HttpResponse browse(StaplerRequest request, StaplerResponse response, Job<?,?> job, String name) {
+    public HttpResponse browse(StaplerRequest request, StaplerResponse response, Job<?, ?> job, String name) {
         return new DirectoryBrowserSupport(job, file, "Cache of " + name, "folder.png", true);
     }
 
@@ -98,8 +98,8 @@ public class LocalObjectPath extends ObjectPath {
 
         private final FilePath toCompare;
 
-        public IsModifiedGlob(String includes, String excludes, FilePath toCompare) {
-            super(includes, excludes);
+        public IsModifiedGlob(String includes, String excludes, boolean useDefaultExcludes, FilePath toCompare) {
+            super(includes, excludes, useDefaultExcludes);
             this.toCompare = toCompare;
         }
 

--- a/src/main/java/jenkins/plugins/itemstorage/s3/S3DownloadAllCallable.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/S3DownloadAllCallable.java
@@ -46,12 +46,12 @@ public class S3DownloadAllCallable extends S3Callable<Integer> {
     private final DirScanner.Glob scanner;
 
 
-    public S3DownloadAllCallable(ClientHelper helper, String fileMask, String excludes, String bucketName, String pathPrefix) {
+    public S3DownloadAllCallable(ClientHelper helper, String fileMask, String excludes, boolean useDefaultExcludes, String bucketName, String pathPrefix) {
         super(helper);
         this.bucketName = bucketName;
         this.pathPrefix = pathPrefix;
 
-        scanner = new DirScanner.Glob(fileMask, excludes);
+        scanner = new DirScanner.Glob(fileMask, excludes, useDefaultExcludes);
     }
 
     /**

--- a/src/main/java/jenkins/plugins/itemstorage/s3/S3ObjectPath.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/S3ObjectPath.java
@@ -60,13 +60,13 @@ public class S3ObjectPath extends ObjectPath {
     }
 
     @Override
-    public int copyRecursiveTo(String fileMask, String excludes, FilePath target) throws IOException, InterruptedException {
-        return profile.download(bucketName, fullName + "/" + path, fileMask, excludes, target);
+    public int copyRecursiveTo(String fileMask, String excludes, boolean useDefaultExcludes, FilePath target) throws IOException, InterruptedException {
+        return profile.download(bucketName, fullName + "/" + path, fileMask, excludes, useDefaultExcludes, target);
     }
 
     @Override
-    public int copyRecursiveFrom(String fileMask, String excludes, FilePath source) throws IOException, InterruptedException {
-        return profile.upload(bucketName, fullName + "/" + path, fileMask, excludes, source, Collections.emptyMap(), null, false);
+    public int copyRecursiveFrom(String fileMask, String excludes, boolean useDefaultExcludes, FilePath source) throws IOException, InterruptedException {
+        return profile.upload(bucketName, fullName + "/" + path, fileMask, excludes, useDefaultExcludes, source, Collections.emptyMap(), null, false);
     }
 
     @Override
@@ -80,7 +80,7 @@ public class S3ObjectPath extends ObjectPath {
     }
 
     @Override
-    public HttpResponse browse(StaplerRequest request, StaplerResponse response, Job<?,?> job, String name) throws IOException {
+    public HttpResponse browse(StaplerRequest request, StaplerResponse response, Job<?, ?> job, String name) throws IOException {
         // For now attempt to forward to s3 for browsing
         response.sendRedirect2("https://console.aws.amazon.com/s3/home?region=" + region + "#&bucket=" + bucketName + "&prefix=" + fullName + "/" + path + "/");
         return null;

--- a/src/main/java/jenkins/plugins/itemstorage/s3/S3Profile.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/S3Profile.java
@@ -62,6 +62,7 @@ public class S3Profile {
                       final String path,
                       final String fileMask,
                       final String excludes,
+                      boolean useDefaultExcludes,
                       final FilePath source,
                       final Map<String, String> userMetadata,
                       final String storageClass,
@@ -70,6 +71,7 @@ public class S3Profile {
                 helper,
                 fileMask,
                 excludes,
+                useDefaultExcludes,
                 bucketName,
                 path,
                 userMetadata,
@@ -85,8 +87,8 @@ public class S3Profile {
         return !objectListing.getObjectSummaries().isEmpty();
     }
 
-    public int download(String bucketName, String pathPrefix, String fileMask, String excludes, FilePath target) throws IOException, InterruptedException {
-        FilePath.FileCallable<Integer> download = new S3DownloadAllCallable(helper, fileMask, excludes, bucketName, pathPrefix);
+    public int download(String bucketName, String pathPrefix, String fileMask, String excludes, boolean useDefaultExcludes, FilePath target) throws IOException, InterruptedException {
+        FilePath.FileCallable<Integer> download = new S3DownloadAllCallable(helper, fileMask, excludes, useDefaultExcludes, bucketName, pathPrefix);
 
         return target.act(download);
     }

--- a/src/main/java/jenkins/plugins/itemstorage/s3/S3UploadAllCallable.java
+++ b/src/main/java/jenkins/plugins/itemstorage/s3/S3UploadAllCallable.java
@@ -51,12 +51,12 @@ public class S3UploadAllCallable extends S3BaseUploadCallable<Integer> {
     private final DirScanner.Glob scanner;
 
 
-    public S3UploadAllCallable(ClientHelper clientHelper, String fileMask, String excludes, String bucketName, String pathPrefix, Map<String, String> userMetadata, String storageClass, boolean useServerSideEncryption) {
+    public S3UploadAllCallable(ClientHelper clientHelper, String fileMask, String excludes, boolean useDefaultExcludes, String bucketName, String pathPrefix, Map<String, String> userMetadata, String storageClass, boolean useServerSideEncryption) {
         super(clientHelper, userMetadata, storageClass, useServerSideEncryption);
         this.bucketName = bucketName;
         this.pathPrefix = pathPrefix;
 
-        scanner = new DirScanner.Glob(fileMask, excludes);
+        scanner = new DirScanner.Glob(fileMask, excludes, useDefaultExcludes);
     }
 
     /**

--- a/src/main/java/jenkins/plugins/jobcacher/ArbitraryFileCache.java
+++ b/src/main/java/jenkins/plugins/jobcacher/ArbitraryFileCache.java
@@ -56,12 +56,22 @@ public class ArbitraryFileCache extends Cache {
     private String path;
     private String includes = "**/*";
     private String excludes;
+    private boolean useDefaultExcludes = true;
 
     @DataBoundConstructor
     public ArbitraryFileCache(String path, String includes, String excludes) {
         this.path = path;
         this.includes = StringUtils.isNotBlank(includes) ? includes : "**/*";
         this.excludes = excludes;
+    }
+
+    @DataBoundSetter
+    public void setUseDefaultExcludes(boolean useDefaultExcludes) {
+        this.useDefaultExcludes = useDefaultExcludes;
+    }
+
+    public boolean getUseDefaultExcludes() {
+        return useDefaultExcludes;
     }
 
     public String getPath() {
@@ -106,7 +116,7 @@ public class ArbitraryFileCache extends Cache {
         // Resolve path variables if any
         String expandedPath = initialEnvironment.expand(path);
 
-        cachePath(source, defaultSource, workspace, listener, expandedPath, includes, excludes);
+        cachePath(source, defaultSource, workspace, listener, expandedPath, includes, excludes, useDefaultExcludes);
 
         return new SaverImpl(expandedPath);
     }
@@ -134,7 +144,7 @@ public class ArbitraryFileCache extends Cache {
             // Get a target dir for cached files for this path
             ObjectPath target = cache.child(deriveCachePath(path));
 
-            savePath(target, workspace, listener, expandedPath, includes, excludes);
+            savePath(target, workspace, listener, expandedPath, includes, excludes, useDefaultExcludes);
         }
     }
 

--- a/src/main/java/jenkins/plugins/jobcacher/Cache.java
+++ b/src/main/java/jenkins/plugins/jobcacher/Cache.java
@@ -71,16 +71,17 @@ public abstract class Cache extends AbstractDescribableImpl<Cache> implements Ex
     /**
      * This method recursively copies files from the sourceDir to the path on the executor
      *
-     * @param source The source directory of the cache
-     * @param workspace The executor workspace that the destination path will be referenced
-     * @param listener The task listener
-     * @param path The path on the executor to store the source cache on
-     * @param includes The glob expression that will filter the contents of the path
-     * @param excludes The excludes expression that will filter contents of the path
-     * @throws IOException If an error occurs connecting to the potentially remote executor
+     * @param source             The source directory of the cache
+     * @param workspace          The executor workspace that the destination path will be referenced
+     * @param listener           The task listener
+     * @param path               The path on the executor to store the source cache on
+     * @param includes           The glob expression that will filter the contents of the path
+     * @param excludes           The excludes expression that will filter contents of the path
+     * @param useDefaultExcludes Whether to use default excludes additionally to the manually specified excludes
+     * @throws IOException          If an error occurs connecting to the potentially remote executor
      * @throws InterruptedException If interrupted
      */
-    protected void cachePath(ObjectPath source, ObjectPath defaultSource, FilePath workspace, TaskListener listener, String path, String includes, String excludes) throws IOException, InterruptedException {
+    protected void cachePath(ObjectPath source, ObjectPath defaultSource, FilePath workspace, TaskListener listener, String path, String includes, String excludes, boolean useDefaultExcludes) throws IOException, InterruptedException {
 
         if (source.exists() || (defaultSource != null && defaultSource.exists())) {
             FilePath targetDirectory = workspace.child(path);
@@ -91,10 +92,10 @@ public abstract class Cache extends AbstractDescribableImpl<Cache> implements Ex
 
             if (source.exists()) {
                 listener.getLogger().println("Caching " + path + " to executor");
-                source.copyRecursiveTo(includes, excludes, targetDirectory);
+                source.copyRecursiveTo(includes, excludes, useDefaultExcludes, targetDirectory);
             } else {
                 listener.getLogger().println("Caching " + path + " to executor using default cache");
-                defaultSource.copyRecursiveTo(includes, excludes, targetDirectory);
+                defaultSource.copyRecursiveTo(includes, excludes, useDefaultExcludes, targetDirectory);
             }
         } else {
             listener.getLogger().println("Skip caching as no cache exists for " + path);
@@ -141,22 +142,23 @@ public abstract class Cache extends AbstractDescribableImpl<Cache> implements Ex
         /**
          * This method recursively copies files from the path on the executor to the master target directory
          *
-         * @param target The target directory of the cache
-         * @param workspace The executor workspace that the destination path will be referenced
-         * @param listener The task listener
-         * @param path The path on the executor to store the source cache on
-         * @param includes The glob expression that will filter the contents of the path
-         * @param excludes The excludes expression that will filter contents of the path
-         * @throws IOException If an error occurs connecting to the potentially remote executor
+         * @param target             The target directory of the cache
+         * @param workspace          The executor workspace that the destination path will be referenced
+         * @param listener           The task listener
+         * @param path               The path on the executor to store the source cache on
+         * @param includes           The glob expression that will filter the contents of the path
+         * @param excludes           The excludes expression that will filter contents of the path
+         * @param useDefaultExcludes Whether to use default excludes additionally to the manually specified excludes
+         * @throws IOException          If an error occurs connecting to the potentially remote executor
          * @throws InterruptedException If interrupted
          */
-        protected void savePath(ObjectPath target, FilePath workspace, TaskListener listener, String path, String includes, String excludes) throws IOException, InterruptedException {
+        protected void savePath(ObjectPath target, FilePath workspace, TaskListener listener, String path, String includes, String excludes, boolean useDefaultExcludes) throws IOException, InterruptedException {
 
             FilePath source = workspace.child(path);
 
             listener.getLogger().println("Storing " + path + " in cache");
 
-            target.copyRecursiveFrom(includes, excludes, source);
+            target.copyRecursiveFrom(includes, excludes, useDefaultExcludes, source);
         }
     }
 

--- a/src/main/resources/jenkins/plugins/jobcacher/ArbitraryFileCache/config.jelly
+++ b/src/main/resources/jenkins/plugins/jobcacher/ArbitraryFileCache/config.jelly
@@ -38,5 +38,9 @@
         <f:entry title="${%Excludes}" field="excludes">
             <f:textbox />
         </f:entry>
+
+        <f:entry title="${%UseDefaultExcludes}" field="useDefaultExcludes">
+            <f:checkbox default="true"/>
+        </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/jobcacher/ArbitraryFileCache/help-useDefaultExcludes.html
+++ b/src/main/resources/jenkins/plugins/jobcacher/ArbitraryFileCache/help-useDefaultExcludes.html
@@ -1,0 +1,27 @@
+<!--
+  - The MIT License
+  -
+  - Copyright (c) 2011, Manufacture Francaise des Pneumatiques Michelin, Romain Seguy
+  -
+  - Permission is hereby granted, free of charge, to any person obtaining a copy
+  - of this software and associated documentation files (the "Software"), to deal
+  - in the Software without restriction, including without limitation the rights
+  - to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  - copies of the Software, and to permit persons to whom the Software is
+  - furnished to do so, subject to the following conditions:
+  -
+  - The above copyright notice and this permission notice shall be included in
+  - all copies or substantial portions of the Software.
+  -
+  - THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  - IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  - FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  - AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  - LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  - OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  - THE SOFTWARE.
+  -->
+
+<div>
+    Whether to use the default excludes (see <a target="_blank" href="https://github.com/apache/ant/blob/eeacf501dd15327cd300ecd518284e68bb5af4a4/src/main/org/apache/tools/ant/DirectoryScanner.java#L170">DirectoryScanner#DEFAULTEXCLUDES</a> for more details).
+</div>


### PR DESCRIPTION
Added option to ArbitraryFileCache to deactivate default excludes (fixes #39). This will not change the default behavior, but allows users to deactivate it if necessary.

I did not add any automatic tests, but did some manual testing.